### PR TITLE
Uniform orgRegistry capitalization in md files

### DIFF
--- a/docs/baseline-basics/glossary.md
+++ b/docs/baseline-basics/glossary.md
@@ -26,7 +26,7 @@ WIP section - Placeholder for future updates
 
 ### Workgroup
 
-A set of Parties \(defined in the orgRegistry\) when a Registrar factory smart contract is called to start a Workflow.
+A set of Parties \(defined in the OrgRegistry\) when a Registrar factory smart contract is called to start a Workflow.
 
 ### Workflow
 
@@ -50,15 +50,15 @@ In Radish34, there isn't a coherent "Baseline Server", but in the ultimate refer
 
 ### Baseline Proof
 
-There are several things passed to the Mainnet, primarily from the ZK Service, in the process of _baselining_ a Workflow Step. An important one is a hash, which is stored in the Shield contract \(created when setting up a WorkGroup by the Registrar "factory" smart contract, along with the orgRegistry and Validator contract\). This happens when a Step successfully passes the ZK validation process. The Baseline Proof is a "proof of consistency" _token_, and also is used as a state-marker for managing Workflow integrity.
+There are several things passed to the Mainnet, primarily from the ZK Service, in the process of _baselining_ a Workflow Step. An important one is a hash, which is stored in the Shield contract \(created when setting up a WorkGroup by the Registrar "factory" smart contract, along with the OrgRegistry and Validator contract\). This happens when a Step successfully passes the ZK validation process. The Baseline Proof is a "proof of consistency" _token_, and also is used as a state-marker for managing Workflow integrity.
 
 ### CodeBook =&gt; Package
 
 During the Radish34 project, the notion of a shared "codebook" was often discussed. This in concept refers to a collection of artifacts or library components that enable a business process to be "baselined", but in general is extensible to any such components that subject to a business process. These artifacts in the case of Radish34 and presumably what would be "importable" components include the zk snark based circuits for usage in off chain zkp based proof generation and/or other logical components representing a business logic in a workflow process.
 
-### orgRegistry Contract
+### OrgRegistry Contract
 
-Think of the orgRegistry Contract as a "rolodex" contacts list. In the future, and in particular when the decentralized identity standard \(DID\) is well established, this can be populated from a global "phone book" of pre-verified organizations..so you know when you add a company to your WorkGroup, you are baselining with the company you think you're working with.
+Think of the OrgRegistry Contract as a "rolodex" contacts list. In the future, and in particular when the decentralized identity standard \(DID\) is well established, this can be populated from a global "phone book" of pre-verified organizations..so you know when you add a company to your WorkGroup, you are baselining with the company you think you're working with.
 
 ### Shield Contract
 

--- a/docs/baseline-protocol/baseline-process.md
+++ b/docs/baseline-protocol/baseline-process.md
@@ -16,7 +16,7 @@ The first step in baselining is setting up the counterparties that will be invol
 
 > #### _A Corporate Phone Book?_
 >
-> _It is possible over time for a single instance of an orgRegistry contract on the Mainnet to become a defacto "phone book" for all baselining counterparties. This would provide a convenient place to look up others and to quickly start private Workflows with them. For this to become a reality, such an orgRegistry would need to include appropriate and effective ways to verify that the entry for any given company is the authentic and correct entry for baselining with that entity. **This is an opportunity for engineers and companies to add functionality to the Baseline Protocol.**_
+> _It is possible over time for a single instance of an OrgRegistry contract on the Mainnet to become a defacto "phone book" for all baselining counterparties. This would provide a convenient place to look up others and to quickly start private Workflows with them. For this to become a reality, such an OrgRegistry would need to include appropriate and effective ways to verify that the entry for any given company is the authentic and correct entry for baselining with that entity. **This is an opportunity for engineers and companies to add functionality to the Baseline Protocol.**_
 
 Next, establish point-to-point connectivity with the counterparties in your Workgroup by:
 

--- a/docs/baseline-protocol/components.md
+++ b/docs/baseline-protocol/components.md
@@ -12,9 +12,9 @@ The Registrar contract generates the three main contracts on the Mainnet to boot
 
 ## On-Chain Components <a id="on-chain-components"></a>
 
-### orgRegistry Contract <a id="orgregistry-contract"></a>
+### OrgRegistry Contract <a id="orgregistry-contract"></a>
 
-Think of the orgRegistry Contract as a "rolodex" contacts list. In the future, and in particular when the decentralized identity standard \(DID\) is well established, this can be populated from a global "phone book" of pre-verified organizations..so you know when you add a company to your WorkGroup, you are baselining with the company you think you're working with.
+Think of the OrgRegistry Contract as a "rolodex" contacts list. In the future, and in particular when the decentralized identity standard \(DID\) is well established, this can be populated from a global "phone book" of pre-verified organizations..so you know when you add a company to your WorkGroup, you are baselining with the company you think you're working with.
 
 ### Shield Contract <a id="shield-contract"></a>
 
@@ -41,7 +41,7 @@ It has been suggested that the Baseline Protocol community consider looking into
 
 ## ZK Service <a id="zk-service"></a>
 
-zk-SNARK stands for "Zero Knowledge Succinct Non-Interactive Argument of Knowledge", and is a family of privacy tools called zero knowledge proofs \(ZKP\). While other privacy techniques like bulletproofs, ring signatures and stealth addresses, etc. mask the identities of the entities involved in a business transaction, ZKP techniques allow to prove logical statements without divulging any information and yet proving the validity of such proofs. Particularly, zk-SNARKs are mathematical concepts and tools to establish zero knowledge verification of succinct proofs, which convert logical statements to arithmetic circuits, that are then leveraged to generate proofs.
+zk-SNARK stands for "Zero Knowledge Succinct Non-Interactive Argument of Knowledge", and is a family of privacy tools called zero knowledge proofs \(ZKP\). While other privacy techniques like bulletproofs, ring signatures and stealth addresses, etc. mask the identities of the entities involved in a business transaction, ZKP techniques allow proving logical statements without divulging any information and yet proving the validity of such proofs. Particularly, zk-SNARKs are mathematical concepts and tools to establish zero knowledge verification of succinct proofs, which convert logical statements to arithmetic circuits, that are then leveraged to generate proofs.
 
 > Normally zk-SNARKs are used as a way to say "I have a secret" to someone and prove that you indeed have the secret without telling them what the secret is. What the Baseline Protocol uses it for is a little different. It's more like saying to a specific set of counterparties, "We have a secret" and using a machine that we all can access to tell us that we all have the same secret \(or that we do not\) _without_ telling that machine anything that would let someone else with access to it discover anything about the secret...or even that we have one.
 
@@ -69,7 +69,7 @@ In the Radish34 Demo, the team built a simple web-based UI to simulate the user 
 
 In the real world, the user experience is the experience of any number of products.
 
-If you are are in charge of the feature/benefit mix of a product in ERP, CRM, SCM, Core Banking or any other type of system of record, you can use the example in the Radish34 UI section to get ideas for how to integrate with baseline components \(whether they have added to your product's internal services or whether they have been deployed as services in your wider IT environment\) and present baselining benefits to users.
+If you are in charge of the feature/benefit mix of a product in ERP, CRM, SCM, Core Banking or any other type of system of record, you can use the example in the Radish34 UI section to get ideas for how to integrate with baseline components \(whether they have added to your product's internal services or whether they have been deployed as services in your wider IT environment\) and present baselining benefits to users.
 
 ​
 

--- a/docs/specs/api/baseline-api-v1.0-psd01.md
+++ b/docs/specs/api/baseline-api-v1.0-psd01.md
@@ -303,7 +303,7 @@ Describes the object providing metadata information about the API (example: titl
 | ORGM1|**#Workgroup**<br>**id:**  <br>**createdAt:**  <br>**networkId:** <br>**userId:** <br> **name**: <br>**description:**<br>**type:**<br>**config:**<br>**hidden:**|
 | ORGM2|**#Organization**<br> {id, createdAt, name, userId, description, metadata}|
 | ORGM3|**#User**<br>{id, createdAt, name, firstName, lastName, email, permissions}\|
-| ORGM4|**#orgRegistry**<br>|
+| ORGM4|**#OrgRegistry**<br>|
 
 ## 4.1.1 Examples
 
@@ -361,7 +361,7 @@ User {
 
 
 
-## 4.2.4 orgRegistry
+## 4.2.4 OrgRegistry
 
 
 ## 4.2 Messaging


### PR DESCRIPTION
# Description

I noticed orgRegistry should start with upper case in couple of md files, to be uniform with other occurrences.

## Related Issue

No related issues.

## Motivation and Context

Just small consistency improvement across docs.

## How Has This Been Tested

As this is just md file, no testing required. 

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
