### PR TITLE
806 endpoint to fetch state leaf based on cah

### DIFF
--- a/examples/bri-3/src/bri/merkleTree/models/bpiMerkleTree.ts
+++ b/examples/bri-3/src/bri/merkleTree/models/bpiMerkleTree.ts
@@ -24,14 +24,18 @@ export class BpiMerkleTree {
 
   public addLeaf(leaf: string): void {
     const bufferLeaf = Buffer.from(leaf, 'utf-8');
-    this.tree.addLeaf(bufferLeaf, true);
+    this.tree.addLeaf(bufferLeaf, false);
   }
 
   public getLeafIndex(leaf: string): number {
     return this.tree.getLeafIndex(Buffer.from(leaf, 'utf-8'));
   }
 
+  public getLeaf(index: number): string {
+    return this.tree.getLeaf(index).toString();
+  }
+
   public getRoot(): string {
-    return this.tree.getHexRoot();
+    return this.tree.getRoot().toString();
   }
 }

--- a/examples/bri-3/src/bri/state/state.module.ts
+++ b/examples/bri-3/src/bri/state/state.module.ts
@@ -1,12 +1,18 @@
 import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
-import { AccountModule } from './bpiAccounts/accounts.module';
 import { MerkleModule } from '../merkleTree/merkle.module';
 import { StateAgent } from './agents/state.agent';
+import { StateController } from './api/state.controller';
+import { AccountModule } from './bpiAccounts/accounts.module';
+import { GetStateTreeLeafValueContentQueryHandler } from './capabilities/getStateContent/getStateTreeLeafValueContentQuery.handler';
+import { StateProfile } from './state.profile';
+
+export const QueryHandlers = [GetStateTreeLeafValueContentQueryHandler];
 
 @Module({
   imports: [CqrsModule, MerkleModule, AccountModule],
-  providers: [StateAgent],
+  controllers: [StateController],
+  providers: [...QueryHandlers, StateAgent, StateProfile],
   exports: [StateAgent],
 })
 export class StateModule {}

--- a/examples/bri-3/test/bri.postman_collection.json
+++ b/examples/bri-3/test/bri.postman_collection.json
@@ -1183,6 +1183,36 @@
 					"response": []
 				}
 			]
+		},
+		{
+			"name": "State",
+			"item": [
+				{
+					"name": "Get state leaf",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:3000/state?leafValue=b7f9a093718ccbf28cb838042efc1ae19a9e78dcf3b95d928a447230fee30960",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "3000",
+							"path": [
+								"state"
+							],
+							"query": [
+								{
+									"key": "leafValue",
+									"value": "b7f9a093718ccbf28cb838042efc1ae19a9e78dcf3b95d928a447230fee30960"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
 		}
 	],
 	"auth": {

--- a/examples/bri-3/test/sriUseCase.e2e-spec.ts
+++ b/examples/bri-3/test/sriUseCase.e2e-spec.ts
@@ -8,12 +8,17 @@ import { AppModule } from '../src/app.module';
 import { BpiMerkleTree } from '../src/bri/merkleTree/models/bpiMerkleTree';
 import { MerkleTreeService } from '../src/bri/merkleTree/services/merkleTree.service';
 import {
-  buyerBpiSubjectEcdsaPrivateKey, buyerBpiSubjectEcdsaPublicKey, internalBpiSubjectEcdsaPrivateKey, internalBpiSubjectEcdsaPublicKey, supplierBpiSubjectEcdsaPrivateKey, supplierBpiSubjectEcdsaPublicKey
+  buyerBpiSubjectEcdsaPrivateKey,
+  buyerBpiSubjectEcdsaPublicKey,
+  internalBpiSubjectEcdsaPrivateKey,
+  internalBpiSubjectEcdsaPublicKey,
+  supplierBpiSubjectEcdsaPrivateKey,
+  supplierBpiSubjectEcdsaPublicKey,
 } from '../src/shared/testing/constants';
 import {
   createEddsaPrivateKey,
   createEddsaPublicKey,
-  createEddsaSignature
+  createEddsaSignature,
 } from '../src/shared/testing/utils';
 
 jest.setTimeout(240000);
@@ -250,28 +255,33 @@ describe('SRI use-case end-to-end test', () => {
     const resultBpiAccount = await fetchBpiAccount(resultWorkflow.bpiAccountId);
 
     const stateBpiMerkleTree = new BpiMerkleTree(
-      "ttt", 
-      "sha256", 
+      'ttt',
+      'sha256',
       MerkleTree.unmarshalTree(
         resultBpiAccount.stateTree.tree,
-        new MerkleTreeService().createHashFunction("sha256"),
-    ));
+        new MerkleTreeService().createHashFunction('sha256'),
+      ),
+    );
 
     const historyBpiMerkleTree = new BpiMerkleTree(
-      "ttt", 
-      "sha256",
+      'ttt',
+      'sha256',
       MerkleTree.unmarshalTree(
         resultBpiAccount.historyTree.tree,
-        new MerkleTreeService().createHashFunction("sha256"),
-    ));
+        new MerkleTreeService().createHashFunction('sha256'),
+      ),
+    );
 
-    expect(historyBpiMerkleTree.getLeafIndex(stateBpiMerkleTree.getRoot())).toBe(0);
+    expect(
+      historyBpiMerkleTree.getLeafIndex(stateBpiMerkleTree.getRoot()),
+    ).toBe(0);
 
-    const stateTreeLeafValue = await fetchStateTreeLeafViaCAH(stateBpiMerkleTree.getLeaf(0));
-    
+    const stateTreeLeafValue = await fetchStateTreeLeafViaCAH(
+      stateBpiMerkleTree.getLeaf(0),
+    );
+
     expect(stateTreeLeafValue.leafIndex).toBe(0);
   });
-  
 
   it('Submits transaction 2 for execution of the workstep 2', async () => {
     await createTransactionAndReturnId(
@@ -304,25 +314,31 @@ describe('SRI use-case end-to-end test', () => {
     const resultBpiAccount = await fetchBpiAccount(resultWorkflow.bpiAccountId);
 
     const stateBpiMerkleTree = new BpiMerkleTree(
-      "ttt", 
-      "sha256", 
+      'ttt',
+      'sha256',
       MerkleTree.unmarshalTree(
         resultBpiAccount.stateTree.tree,
-        new MerkleTreeService().createHashFunction("sha256"),
-    ));
+        new MerkleTreeService().createHashFunction('sha256'),
+      ),
+    );
 
     const historyBpiMerkleTree = new BpiMerkleTree(
-      "ttt", 
-      "sha256",
+      'ttt',
+      'sha256',
       MerkleTree.unmarshalTree(
         resultBpiAccount.historyTree.tree,
-        new MerkleTreeService().createHashFunction("sha256"),
-    ));
+        new MerkleTreeService().createHashFunction('sha256'),
+      ),
+    );
 
-    expect(historyBpiMerkleTree.getLeafIndex(stateBpiMerkleTree.getRoot())).toBe(1);
+    expect(
+      historyBpiMerkleTree.getLeafIndex(stateBpiMerkleTree.getRoot()),
+    ).toBe(1);
 
-    const stateTreeLeafValue = await fetchStateTreeLeafViaCAH(stateBpiMerkleTree.getLeaf(1));
-    
+    const stateTreeLeafValue = await fetchStateTreeLeafViaCAH(
+      stateBpiMerkleTree.getLeaf(1),
+    );
+
     expect(stateTreeLeafValue.leafIndex).toBe(1);
   });
 
@@ -357,25 +373,31 @@ describe('SRI use-case end-to-end test', () => {
     const resultBpiAccount = await fetchBpiAccount(resultWorkflow.bpiAccountId);
 
     const stateBpiMerkleTree = new BpiMerkleTree(
-      "ttt", 
-      "sha256", 
+      'ttt',
+      'sha256',
       MerkleTree.unmarshalTree(
         resultBpiAccount.stateTree.tree,
-        new MerkleTreeService().createHashFunction("sha256"),
-    ));
+        new MerkleTreeService().createHashFunction('sha256'),
+      ),
+    );
 
     const historyBpiMerkleTree = new BpiMerkleTree(
-      "ttt", 
-      "sha256",
+      'ttt',
+      'sha256',
       MerkleTree.unmarshalTree(
         resultBpiAccount.historyTree.tree,
-        new MerkleTreeService().createHashFunction("sha256"),
-    ));
+        new MerkleTreeService().createHashFunction('sha256'),
+      ),
+    );
 
-    expect(historyBpiMerkleTree.getLeafIndex(stateBpiMerkleTree.getRoot())).toBe(2);
+    expect(
+      historyBpiMerkleTree.getLeafIndex(stateBpiMerkleTree.getRoot()),
+    ).toBe(2);
 
-    const stateTreeLeafValue = await fetchStateTreeLeafViaCAH(stateBpiMerkleTree.getLeaf(2));
-    
+    const stateTreeLeafValue = await fetchStateTreeLeafViaCAH(
+      stateBpiMerkleTree.getLeaf(2),
+    );
+
     expect(stateTreeLeafValue.leafIndex).toBe(2);
   });
 });


### PR DESCRIPTION
# Description

Extends the  e2e test to verify that state and history tree entries are correct, as well as verify that the state tree leaf value can be correctly fetched by using content addressable hash.

## Related Issue

#806 

## Motivation and Context

Verification that proper storage happens after each tx execution

## How Has This Been Tested

e2e test extended

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Request to be added as a Code Owner/Maintainer

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I commit to abide by the Responsibilities of Code Owners/Maintainers.
