### PR TITLE
SRI - 810 Use workstepInstanceId for storing CAH in the CCSM contract

### DIFF
--- a/examples/bri-3/ccsm/contracts/CcsmBpiStateAnchor.sol
+++ b/examples/bri-3/ccsm/contracts/CcsmBpiStateAnchor.sol
@@ -5,7 +5,7 @@ import '@openzeppelin/contracts/access/AccessControl.sol';
 
 contract CcsmBpiStateAnchor is AccessControl {
   mapping(string => string) public anchorHashStore;
-  event AnchorHashSet(string indexed workgroupId, string anchorHash);
+  event AnchorHashSet(string indexed workstepInstanceId, string anchorHash);
 
   bytes32 public constant ADMIN_ROLE = keccak256('ADMIN_ROLE');
 
@@ -18,13 +18,16 @@ contract CcsmBpiStateAnchor is AccessControl {
   }
 
   function setAnchorHash(
-    string calldata _workgroupId,
+    string calldata _workstepInstanceId,
     string calldata _anchorHash
   ) external onlyAdmin {
-    require(bytes(_workgroupId).length > 0, 'WorkgroupId cannot be empty');
     require(
-      bytes(_workgroupId).length < 36,
-      'WorkgroupId cannot exceed 36 bytes'
+      bytes(_workstepInstanceId).length > 0,
+      'WorkstepInstanceId cannot be empty'
+    );
+    require(
+      bytes(_workstepInstanceId).length < 36,
+      'WorkstepInstanceId cannot exceed 36 bytes'
     );
     require(bytes(_anchorHash).length > 0, 'AnchorHash cannot be empty');
     require(
@@ -32,15 +35,15 @@ contract CcsmBpiStateAnchor is AccessControl {
       'AnchorHash cannot exceed 256 bytes'
     );
 
-    anchorHashStore[_workgroupId] = _anchorHash;
+    anchorHashStore[_workstepInstanceId] = _anchorHash;
 
-    emit AnchorHashSet(_workgroupId, _anchorHash);
+    emit AnchorHashSet(_workstepInstanceId, _anchorHash);
   }
 
   function getAnchorHash(
-    string calldata _workgroupId
+    string calldata _workstepInstanceId
   ) external view returns (string memory) {
-    return anchorHashStore[_workgroupId];
+    return anchorHashStore[_workstepInstanceId];
   }
 
   modifier onlyAdmin() {

--- a/examples/bri-3/ccsm/test/CcsmBpiStateAnchor.ts
+++ b/examples/bri-3/ccsm/test/CcsmBpiStateAnchor.ts
@@ -1,127 +1,187 @@
-import {
-  loadFixture,
-} from "@nomicfoundation/hardhat-toolbox/network-helpers";
-import { expect } from "chai";
-import hre from "hardhat";
+import { loadFixture } from '@nomicfoundation/hardhat-toolbox/network-helpers';
+import { expect } from 'chai';
+import hre from 'hardhat';
 
-describe("CcsmBpiStateAnchor", function () {
+describe('CcsmBpiStateAnchor', function () {
   async function deployCcsmBpiStateAnchor() {
     const [owner, otherAccount, adminAccount] = await hre.ethers.getSigners();
 
-    const CcsmBpiStateAnchor = await hre.ethers.getContractFactory("CcsmBpiStateAnchor");
-    const ccsmBpiStateAnchor = await CcsmBpiStateAnchor.deploy([await owner.getAddress(), await adminAccount.getAddress()]);
+    const CcsmBpiStateAnchor = await hre.ethers.getContractFactory(
+      'CcsmBpiStateAnchor',
+    );
+    const ccsmBpiStateAnchor = await CcsmBpiStateAnchor.deploy([
+      await owner.getAddress(),
+      await adminAccount.getAddress(),
+    ]);
 
     return { ccsmBpiStateAnchor, owner, otherAccount, adminAccount };
   }
 
-  describe("Deployment", function () {
-    it("Should deploy the contract", async function () {
-      const { ccsmBpiStateAnchor } = await loadFixture(deployCcsmBpiStateAnchor);
+  describe('Deployment', function () {
+    it('Should deploy the contract', async function () {
+      const { ccsmBpiStateAnchor } = await loadFixture(
+        deployCcsmBpiStateAnchor,
+      );
       expect(await ccsmBpiStateAnchor.getAddress()).to.be.properAddress;
     });
 
-    it("Should set the correct admin roles", async function () {
-      const { ccsmBpiStateAnchor, owner, adminAccount } = await loadFixture(deployCcsmBpiStateAnchor);
+    it('Should set the correct admin roles', async function () {
+      const { ccsmBpiStateAnchor, owner, adminAccount } = await loadFixture(
+        deployCcsmBpiStateAnchor,
+      );
       const adminRole = await ccsmBpiStateAnchor.ADMIN_ROLE();
-      expect(await ccsmBpiStateAnchor.hasRole(adminRole, owner.address)).to.be.true;
-      expect(await ccsmBpiStateAnchor.hasRole(adminRole, adminAccount.address)).to.be.true;
+      expect(await ccsmBpiStateAnchor.hasRole(adminRole, owner.address)).to.be
+        .true;
+      expect(await ccsmBpiStateAnchor.hasRole(adminRole, adminAccount.address))
+        .to.be.true;
     });
   });
 
-  describe("setAnchorHash", function () {
-    it("Should allow an admin to set an anchor hash", async function () {
-      const { ccsmBpiStateAnchor, owner } = await loadFixture(deployCcsmBpiStateAnchor);
-      const workgroupId = "testWorkgroup";
-      const anchorHash = "0x1234567890abcdef";
-      
-      await expect(ccsmBpiStateAnchor.connect(owner).setAnchorHash(workgroupId, anchorHash))
-        .to.emit(ccsmBpiStateAnchor, "AnchorHashSet")
-        .withArgs(workgroupId, anchorHash);
-      
-      expect(await ccsmBpiStateAnchor.anchorHashStore(workgroupId)).to.equal(anchorHash);
+  describe('setAnchorHash', function () {
+    it('Should allow an admin to set an anchor hash', async function () {
+      const { ccsmBpiStateAnchor, owner } = await loadFixture(
+        deployCcsmBpiStateAnchor,
+      );
+      const workstepInstanceId = 'testWorkstepInstance';
+      const anchorHash = '0x1234567890abcdef';
+
+      await expect(
+        ccsmBpiStateAnchor
+          .connect(owner)
+          .setAnchorHash(workstepInstanceId, anchorHash),
+      )
+        .to.emit(ccsmBpiStateAnchor, 'AnchorHashSet')
+        .withArgs(workstepInstanceId, anchorHash);
+
+      expect(
+        await ccsmBpiStateAnchor.anchorHashStore(workstepInstanceId),
+      ).to.equal(anchorHash);
     });
 
-    it("Should not allow a non-admin to set an anchor hash", async function () {
-      const { ccsmBpiStateAnchor, otherAccount } = await loadFixture(deployCcsmBpiStateAnchor);
-      const workgroupId = "testWorkgroup";
-      const anchorHash = "0x1234567890abcdef";
-      
-      await expect(ccsmBpiStateAnchor.connect(otherAccount).setAnchorHash(workgroupId, anchorHash))
-        .to.be.revertedWith("Only admin can call this function");
+    it('Should not allow a non-admin to set an anchor hash', async function () {
+      const { ccsmBpiStateAnchor, otherAccount } = await loadFixture(
+        deployCcsmBpiStateAnchor,
+      );
+      const workstepInstanceId = 'testWorkstepInstance';
+      const anchorHash = '0x1234567890abcdef';
+
+      await expect(
+        ccsmBpiStateAnchor
+          .connect(otherAccount)
+          .setAnchorHash(workstepInstanceId, anchorHash),
+      ).to.be.revertedWith('Only admin can call this function');
     });
 
-    it("Should revert when workgroupId is empty", async function () {
-      const { ccsmBpiStateAnchor, owner } = await loadFixture(deployCcsmBpiStateAnchor);
-      const anchorHash = "0x1234567890abcdef";
-      
-      await expect(ccsmBpiStateAnchor.connect(owner).setAnchorHash("", anchorHash))
-        .to.be.revertedWith("WorkgroupId cannot be empty");
+    it('Should revert when workstepInstanceId is empty', async function () {
+      const { ccsmBpiStateAnchor, owner } = await loadFixture(
+        deployCcsmBpiStateAnchor,
+      );
+      const anchorHash = '0x1234567890abcdef';
+
+      await expect(
+        ccsmBpiStateAnchor.connect(owner).setAnchorHash('', anchorHash),
+      ).to.be.revertedWith('WorkstepInstanceId cannot be empty');
     });
 
-    it("Should revert when workgroupId exceeds 36 bytes", async function () {
-      const { ccsmBpiStateAnchor, owner } = await loadFixture(deployCcsmBpiStateAnchor);
-      const longWorkgroupId = "a".repeat(37);
-      const anchorHash = "0x1234567890abcdef";
-      
-      await expect(ccsmBpiStateAnchor.connect(owner).setAnchorHash(longWorkgroupId, anchorHash))
-        .to.be.revertedWith("WorkgroupId cannot exceed 36 bytes");
+    it('Should revert when workstepInstanceId exceeds 36 bytes', async function () {
+      const { ccsmBpiStateAnchor, owner } = await loadFixture(
+        deployCcsmBpiStateAnchor,
+      );
+      const longWorkstepInstanceId = 'a'.repeat(37);
+      const anchorHash = '0x1234567890abcdef';
+
+      await expect(
+        ccsmBpiStateAnchor
+          .connect(owner)
+          .setAnchorHash(longWorkstepInstanceId, anchorHash),
+      ).to.be.revertedWith('WorkstepInstanceId cannot exceed 36 bytes');
     });
 
-    it("Should revert when anchorHash is empty", async function () {
-      const { ccsmBpiStateAnchor, owner } = await loadFixture(deployCcsmBpiStateAnchor);
-      const workgroupId = "testWorkgroup";
-      
-      await expect(ccsmBpiStateAnchor.connect(owner).setAnchorHash(workgroupId, ""))
-        .to.be.revertedWith("AnchorHash cannot be empty");
+    it('Should revert when anchorHash is empty', async function () {
+      const { ccsmBpiStateAnchor, owner } = await loadFixture(
+        deployCcsmBpiStateAnchor,
+      );
+      const workstepInstanceId = 'testWorkstepInstance';
+
+      await expect(
+        ccsmBpiStateAnchor.connect(owner).setAnchorHash(workstepInstanceId, ''),
+      ).to.be.revertedWith('AnchorHash cannot be empty');
     });
 
-    it("Should revert when anchorHash exceeds 256 bytes", async function () {
-      const { ccsmBpiStateAnchor, owner } = await loadFixture(deployCcsmBpiStateAnchor);
-      const workgroupId = "testWorkgroup";
-      const longAnchorHash = "0x" + "a".repeat(257);
-      
-      await expect(ccsmBpiStateAnchor.connect(owner).setAnchorHash(workgroupId, longAnchorHash))
-        .to.be.revertedWith("AnchorHash cannot exceed 256 bytes");
+    it('Should revert when anchorHash exceeds 256 bytes', async function () {
+      const { ccsmBpiStateAnchor, owner } = await loadFixture(
+        deployCcsmBpiStateAnchor,
+      );
+      const workstepInstanceId = 'testWorkstepInstance';
+      const longAnchorHash = '0x' + 'a'.repeat(257);
+
+      await expect(
+        ccsmBpiStateAnchor
+          .connect(owner)
+          .setAnchorHash(workstepInstanceId, longAnchorHash),
+      ).to.be.revertedWith('AnchorHash cannot exceed 256 bytes');
     });
   });
 
-  describe("getAnchorHash", function () {
-    it("Should return the correct anchor hash for a given workgroupId", async function () {
-      const { ccsmBpiStateAnchor, owner } = await loadFixture(deployCcsmBpiStateAnchor);
-      const workgroupId = "testWorkgroup";
-      const anchorHash = "0x1234567890abcdef";
-      
-      await ccsmBpiStateAnchor.connect(owner).setAnchorHash(workgroupId, anchorHash);
-      expect(await ccsmBpiStateAnchor.getAnchorHash(workgroupId)).to.equal(anchorHash);
+  describe('getAnchorHash', function () {
+    it('Should return the correct anchor hash for a given workstepInstanceId', async function () {
+      const { ccsmBpiStateAnchor, owner } = await loadFixture(
+        deployCcsmBpiStateAnchor,
+      );
+      const workstepInstanceId = 'testWorkstepInstance';
+      const anchorHash = '0x1234567890abcdef';
+
+      await ccsmBpiStateAnchor
+        .connect(owner)
+        .setAnchorHash(workstepInstanceId, anchorHash);
+      expect(
+        await ccsmBpiStateAnchor.getAnchorHash(workstepInstanceId),
+      ).to.equal(anchorHash);
     });
 
-    it("Should return an empty string for a non-existent workgroupId", async function () {
-      const { ccsmBpiStateAnchor } = await loadFixture(deployCcsmBpiStateAnchor);
-      const nonExistentWorkgroupId = "nonExistent";
-      
-      expect(await ccsmBpiStateAnchor.getAnchorHash(nonExistentWorkgroupId)).to.equal("");
+    it('Should return an empty string for a non-existent workstepInstanceId', async function () {
+      const { ccsmBpiStateAnchor } = await loadFixture(
+        deployCcsmBpiStateAnchor,
+      );
+      const nonExistentWorkstepInstanceId = 'nonExistent';
+
+      expect(
+        await ccsmBpiStateAnchor.getAnchorHash(nonExistentWorkstepInstanceId),
+      ).to.equal('');
     });
   });
 
-  describe("AccessControl", function () {
-    it("Should allow the owner to grant admin role", async function () {
-      const { ccsmBpiStateAnchor, owner, otherAccount } = await loadFixture(deployCcsmBpiStateAnchor);
+  describe('AccessControl', function () {
+    it('Should allow the owner to grant admin role', async function () {
+      const { ccsmBpiStateAnchor, owner, otherAccount } = await loadFixture(
+        deployCcsmBpiStateAnchor,
+      );
       const adminRole = await ccsmBpiStateAnchor.ADMIN_ROLE();
-      
-      await expect(ccsmBpiStateAnchor.connect(owner).grantRole(adminRole, otherAccount.address))
-        .to.not.be.reverted;
-      
-      expect(await ccsmBpiStateAnchor.hasRole(adminRole, otherAccount.address)).to.be.true;
+
+      await expect(
+        ccsmBpiStateAnchor
+          .connect(owner)
+          .grantRole(adminRole, otherAccount.address),
+      ).to.not.be.reverted;
+
+      expect(await ccsmBpiStateAnchor.hasRole(adminRole, otherAccount.address))
+        .to.be.true;
     });
 
-    it("Should allow the owner to revoke admin role", async function () {
-      const { ccsmBpiStateAnchor, owner, adminAccount } = await loadFixture(deployCcsmBpiStateAnchor);
+    it('Should allow the owner to revoke admin role', async function () {
+      const { ccsmBpiStateAnchor, owner, adminAccount } = await loadFixture(
+        deployCcsmBpiStateAnchor,
+      );
       const adminRole = await ccsmBpiStateAnchor.ADMIN_ROLE();
-      
-      await expect(ccsmBpiStateAnchor.connect(owner).revokeRole(adminRole, adminAccount.address))
-        .to.not.be.reverted;
-      
-      expect(await ccsmBpiStateAnchor.hasRole(adminRole, adminAccount.address)).to.be.false;
+
+      await expect(
+        ccsmBpiStateAnchor
+          .connect(owner)
+          .revokeRole(adminRole, adminAccount.address),
+      ).to.not.be.reverted;
+
+      expect(await ccsmBpiStateAnchor.hasRole(adminRole, adminAccount.address))
+        .to.be.false;
     });
   });
 });

--- a/examples/bri-3/src/bri/ccsm/services/ccsm.interface.ts
+++ b/examples/bri-3/src/bri/ccsm/services/ccsm.interface.ts
@@ -1,6 +1,9 @@
 import { Contract } from 'ethers';
 export interface ICcsmService {
   connectToContract(): Promise<Contract>;
-  storeAnchorHash(workgroupId: string, anchorHash: string): Promise<void>;
-  getAnchorHash(workgroupId: string): Promise<string>;
+  storeAnchorHash(
+    workstepInstanceId: string,
+    anchorHash: string,
+  ): Promise<void>;
+  getAnchorHash(workstepInstanceId: string): Promise<string>;
 }

--- a/examples/bri-3/src/bri/ccsm/services/ethereum.service.spec.ts
+++ b/examples/bri-3/src/bri/ccsm/services/ethereum.service.spec.ts
@@ -13,27 +13,27 @@ describe.skip('Ethereum services', () => {
   describe('storeAnchorHash', () => {
     it('should set anchor hash in the mapping', async () => {
       //Arrange
-      const workgroupdId = '123';
+      const workstepInstanceId = '123';
       const anchorHash = 'anchorHash';
 
       //Act
-      await ccsm.storeAnchorHash(workgroupdId, anchorHash);
+      await ccsm.storeAnchorHash(workstepInstanceId, anchorHash);
       const ccsmContract = await ccsm.connectToContract();
 
       //Assert
-      expect(await ccsmContract.anchorHashStore(workgroupdId)).toEqual(
+      expect(await ccsmContract.anchorHashStore(workstepInstanceId)).toEqual(
         anchorHash,
       );
     });
   });
   describe('getAnchorHash', () => {
-    it('should get anchor hash of the workgroupId from the mapping', async () => {
+    it('should get anchor hash of the WorkstepInstanceId from the mapping', async () => {
       //Arrange
-      const workgroupdId = '123';
+      const workstepInstanceId = '123';
       const anchorHash = 'anchorHash';
 
       //Act
-      const response = await ccsm.getAnchorHash(workgroupdId);
+      const response = await ccsm.getAnchorHash(workstepInstanceId);
 
       //Assert
       expect(response).toEqual(anchorHash);

--- a/examples/bri-3/src/bri/ccsm/services/ethereum.service.ts
+++ b/examples/bri-3/src/bri/ccsm/services/ethereum.service.ts
@@ -45,12 +45,15 @@ export class EthereumService implements ICcsmService {
   }
 
   public async storeAnchorHash(
-    workgroupId: string,
+    workstepInstanceId: string,
     anchorHash: string,
   ): Promise<void> {
     const ccsmContract = await this.connectToContract();
     try {
-      const tx = await ccsmContract.setAnchorHash(workgroupId, anchorHash);
+      const tx = await ccsmContract.setAnchorHash(
+        workstepInstanceId,
+        anchorHash,
+      );
       await tx.wait();
     } catch (error) {
       throw new InternalServerErrorException(
@@ -59,9 +62,9 @@ export class EthereumService implements ICcsmService {
     }
   }
 
-  public async getAnchorHash(workgroupdId: string): Promise<string> {
+  public async getAnchorHash(workstepInstanceId: string): Promise<string> {
     const ccsmContract = await this.connectToContract();
-    const anchorHash = await ccsmContract.getAnchorHash(workgroupdId);
+    const anchorHash = await ccsmContract.getAnchorHash(workstepInstanceId);
     return anchorHash;
   }
 }

--- a/examples/bri-3/src/bri/ccsm/services/ethereum.service.ts
+++ b/examples/bri-3/src/bri/ccsm/services/ethereum.service.ts
@@ -33,9 +33,8 @@ export class EthereumService implements ICcsmService {
   async connectToContract(): Promise<Contract> {
     const ccsmContractAddress =
       process.env.CCSM_BPI_STATE_ANCHOR_CONTRACT_ADDRESS!;
-    let ccsmBpiStateAnchorContract;
 
-    ccsmBpiStateAnchorContract = new ethers.Contract(
+    const ccsmBpiStateAnchorContract = new ethers.Contract(
       ccsmContractAddress,
       CcsmBpiStateAnchor.abi,
       this.wallet,


### PR DESCRIPTION
# Description

This PR replaces workgroupId with workstepInstanceId in the CCSM contract

## Related Issue

#803 

## How Has This Been Tested

All unit tests are passing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Request to be added as a Code Owner/Maintainer

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I commit to abide by the Responsibilities of Code Owners/Maintainers.
