### PR TITLE
812 deploy contract on e2e test start

### DIFF
--- a/.github/workflows/bri-3.yml
+++ b/.github/workflows/bri-3.yml
@@ -109,6 +109,14 @@ jobs:
         working-directory: examples/bri-3
         run: npx prisma db seed
 
+      - name: Run hardhat
+        working-directory: examples/bri-3/ccsm
+        run: npx hardhat node
+
+      - name: deploy contracts
+        working-directory: examples/bri-3/ccsm
+        run: npx hardhat run scripts/deploy.ts
+
       - name: Run e2e tests
         working-directory: examples/bri-3
         run: npm run test:e2e

--- a/.github/workflows/bri-3.yml
+++ b/.github/workflows/bri-3.yml
@@ -113,13 +113,11 @@ jobs:
         working-directory: examples/bri-3/ccsm
         run: npm ci
 
-      - name: Run hardhat
+      - name: Run hardhat and deploy contracts
         working-directory: examples/bri-3/ccsm
-        run: npx hardhat node
-
-      - name: deploy contracts
-        working-directory: examples/bri-3/ccsm
-        run: npx hardhat run scripts/deploy.ts
+        run: |
+          npx hardhat node &
+          npx hardhat run scripts/deploy.ts
 
       - name: Run e2e tests
         working-directory: examples/bri-3

--- a/.github/workflows/bri-3.yml
+++ b/.github/workflows/bri-3.yml
@@ -108,6 +108,10 @@ jobs:
       - name: Run prisma db seed
         working-directory: examples/bri-3
         run: npx prisma db seed
+      
+      - name: Install hardhar dependencies
+        working-directory: examples/bri-3/ccsm
+        run: npm ci
 
       - name: Run hardhat
         working-directory: examples/bri-3/ccsm

--- a/.github/workflows/bri-3.yml
+++ b/.github/workflows/bri-3.yml
@@ -109,7 +109,7 @@ jobs:
         working-directory: examples/bri-3
         run: npx prisma db seed
       
-      - name: Install hardhar dependencies
+      - name: Install hardhat dependencies
         working-directory: examples/bri-3/ccsm
         run: npm ci
 

--- a/examples/bri-3/README.md
+++ b/examples/bri-3/README.md
@@ -83,12 +83,12 @@ $ npm run test -- transactions.agent.spec.ts
 
 
 ```bash
-# e2e testing - .e2e.spec files located in ./test folder
+# e2e testing - .e2e.spec files and the bash script used for running located in ./test folder
 # before running the tests, make sure that postgres and nats are running
-# and the database is properly populated with the seed.ts command (explained above)
 # also make sure that the .env file contains correct values for DID login to work (as explained in the .env.sample)
 
-$ npm run test:e2e
+$ cd test
+$ sh ./e2e-test.sh
 ```
 
 ## Architecture

--- a/examples/bri-3/ccsm/scripts/deploy.ts
+++ b/examples/bri-3/ccsm/scripts/deploy.ts
@@ -1,0 +1,21 @@
+const hre = require("hardhat");
+
+async function main() {
+  const [owner, adminAccount] = await hre.ethers.getSigners();
+
+  const CcsmBpiStateAnchor = await hre.ethers.getContractFactory("CcsmBpiStateAnchor");
+
+  const ccsmBpiStateAnchor = await CcsmBpiStateAnchor.deploy([
+    await owner.getAddress(),
+    await adminAccount.getAddress(),
+  ]);
+
+  console.log("CcsmBpiStateAnchor deployed to:", await ccsmBpiStateAnchor.getAddress());
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/examples/bri-3/test/e2e-test.sh
+++ b/examples/bri-3/test/e2e-test.sh
@@ -1,5 +1,3 @@
-Shell script to set up, deploy, and run tests
-
 #!/bin/bash
 
 # Function to print messages with timestamps
@@ -38,6 +36,10 @@ run_command "npx hardhat run scripts/deploy.ts"
 log_message "Changing to root directory"
 run_command "cd .."
 
+# Prep database
+log_message "Reset and reseed database"
+run_command "npx prisma migrate reset --force"
+
 # Run e2e tests
 log_message "Running e2e tests"
 run_command "npm run test:e2e"
@@ -45,6 +47,5 @@ run_command "npm run test:e2e"
 # Stop Hardhat node
 log_message "Stopping Hardhat node"
 kill $HARDHAT_PID
-wait $HARDHAT_PID 2>/dev/null
 
 log_message "Script execution completed"


### PR DESCRIPTION
# Description

Adds a deploy script for the BPI contract. 
Adds a bash script to run hardhat node and deploy contract prior to executing the e2e test. 
Adds hardhat node start and deploy contracts to GH action.

## Related Issue

#812 

## Motivation and Context

e2e tests must cover the CCSM part as well.

## How Has This Been Tested

Ran the bash script locally

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Request to be added as a Code Owner/Maintainer

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I commit to abide by the Responsibilities of Code Owners/Maintainers.
