### PR TITLE
SRI - 811 Add workflowId and workstepId to transaction

### DIFF
--- a/examples/bri-3/prisma/migrations/20240722125359_add_workflow_id_and_workstep_id_to_transaction/migration.sql
+++ b/examples/bri-3/prisma/migrations/20240722125359_add_workflow_id_and_workstep_id_to_transaction/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - Added the required column `workflowId` to the `Transaction` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `workstepId` to the `Transaction` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Transaction" ADD COLUMN     "workflowId" TEXT NOT NULL,
+ADD COLUMN     "workstepId" TEXT NOT NULL;

--- a/examples/bri-3/prisma/migrations/20240722130942_add_workflow_id_and_workstep_id_to_transaction/migration.sql
+++ b/examples/bri-3/prisma/migrations/20240722130942_add_workflow_id_and_workstep_id_to_transaction/migration.sql
@@ -7,4 +7,6 @@
 */
 -- AlterTable
 ALTER TABLE "Transaction" ADD COLUMN     "workflowId" TEXT NOT NULL,
-ADD COLUMN     "workstepId" TEXT NOT NULL;
+ADD COLUMN     "workstepId" TEXT NOT NULL,
+ALTER COLUMN "workflowInstanceId" DROP NOT NULL,
+ALTER COLUMN "workstepInstanceId" DROP NOT NULL;

--- a/examples/bri-3/prisma/schema.prisma
+++ b/examples/bri-3/prisma/schema.prisma
@@ -101,9 +101,9 @@ model Transaction {
   id                      String            @id
   nonce                   Int
   workflowId              String
-  workflowInstanceId      String
+  workflowInstanceId      String?
   workstepId              String
-  workstepInstanceId      String
+  workstepInstanceId      String?
   fromBpiSubjectAccountId String
   fromBpiSubjectAccount   BpiSubjectAccount @relation(fields: [fromBpiSubjectAccountId], references: [id], name: "fromBpiSubjectAccount_fk")
   toBpiSubjectAccountId   String

--- a/examples/bri-3/prisma/schema.prisma
+++ b/examples/bri-3/prisma/schema.prisma
@@ -100,7 +100,9 @@ model Workgroup {
 model Transaction {
   id                      String            @id
   nonce                   Int
+  workflowId              String
   workflowInstanceId      String
+  workstepId              String
   workstepInstanceId      String
   fromBpiSubjectAccountId String
   fromBpiSubjectAccount   BpiSubjectAccount @relation(fields: [fromBpiSubjectAccountId], references: [id], name: "fromBpiSubjectAccount_fk")

--- a/examples/bri-3/src/bri/transactions/agents/transactionStorage.agent.ts
+++ b/examples/bri-3/src/bri/transactions/agents/transactionStorage.agent.ts
@@ -96,8 +96,8 @@ export class TransactionStorageAgent {
       data: {
         id: transaction.id,
         nonce: transaction.nonce,
-        workflowInstanceId: transaction.workflowInstanceId,
-        workstepInstanceId: transaction.workstepInstanceId,
+        workflowId: transaction.workflowId,
+        workstepId: transaction.workstepId,
         fromBpiSubjectAccountId: transaction.fromBpiSubjectAccountId,
         toBpiSubjectAccountId: transaction.toBpiSubjectAccountId,
         payload: transaction.payload,

--- a/examples/bri-3/src/bri/transactions/agents/transactions.agent.ts
+++ b/examples/bri-3/src/bri/transactions/agents/transactions.agent.ts
@@ -26,6 +26,7 @@ import {
 } from '../api/err.messages';
 import { TransactionResult } from '../models/transactionResult';
 import { TransactionStorageAgent } from './transactionStorage.agent';
+import { v4 } from 'uuid';
 
 @Injectable()
 export class TransactionAgent {
@@ -131,7 +132,7 @@ export class TransactionAgent {
   ): Promise<boolean> {
     // TODO: Log each validation err for now
     const workflow = await this.workflowStorageAgent.getWorkflowById(
-      tx.workflowInstanceId,
+      tx.workflowId,
     );
 
     if (!workflow) {
@@ -139,7 +140,7 @@ export class TransactionAgent {
     }
 
     const workstep = await this.workstepStorageAgent.getWorkstepById(
-      tx.workstepInstanceId,
+      tx.workstepId,
     );
 
     if (!workstep) {
@@ -183,6 +184,15 @@ export class TransactionAgent {
     workstep: Workstep,
   ): Promise<TransactionResult> {
     const txResult = new TransactionResult();
+
+    //Generate and store workflowInstanceId & workstepInstanceId
+    const workflowInstanceId = v4();
+    const workstepInstanceId = v4();
+
+    tx.updateWorkflowInstanceId(workflowInstanceId);
+    tx.updateWorkstepInstanceId(workstepInstanceId);
+
+    this.txStorageAgent.updateTransaction(tx);
 
     txResult.merkelizedPayload = this.merkleTreeService.merkelizePayload(
       JSON.parse(tx.payload),

--- a/examples/bri-3/src/bri/transactions/agents/transactions.agent.ts
+++ b/examples/bri-3/src/bri/transactions/agents/transactions.agent.ts
@@ -53,8 +53,8 @@ export class TransactionAgent {
   public createNewTransaction(
     id: string,
     nonce: number,
-    workflowInstanceId: string,
-    workstepInstanceId: string,
+    workflowId: string,
+    workstepId: string,
     fromBpiSubjectAccount: BpiSubjectAccount,
     toBpiSubjectAccount: BpiSubjectAccount,
     payload: string,
@@ -63,8 +63,8 @@ export class TransactionAgent {
     return new Transaction(
       id,
       nonce,
-      workflowInstanceId,
-      workstepInstanceId,
+      workflowId,
+      workstepId,
       fromBpiSubjectAccount,
       toBpiSubjectAccount,
       payload,

--- a/examples/bri-3/src/bri/transactions/api/dtos/request/createTransaction.dto.spec.ts
+++ b/examples/bri-3/src/bri/transactions/api/dtos/request/createTransaction.dto.spec.ts
@@ -8,8 +8,8 @@ describe('CreateTransactionDto', () => {
     // Arrange
     const dto = {
       nonce: 123,
-      workflowInstanceId: '123',
-      workstepInstanceId: '123',
+      workflowId: '123',
+      workstepId: '123',
       fromSubjectAccountId: '123',
       toSubjectAccountId: '123',
       payload: '123',
@@ -33,8 +33,8 @@ describe('CreateTransactionDto', () => {
     const dto = {
       id: '123',
       nonce: 123,
-      workflowInstanceId: '123',
-      workstepInstanceId: '123',
+      workflowId: '123',
+      workstepId: '123',
       fromSubjectAccountId: '123',
       toSubjectAccountId: '123',
       payload: '123',

--- a/examples/bri-3/src/bri/transactions/api/dtos/request/createTransaction.dto.ts
+++ b/examples/bri-3/src/bri/transactions/api/dtos/request/createTransaction.dto.ts
@@ -9,10 +9,10 @@ export class CreateTransactionDto {
   nonce: number;
 
   @IsNotEmpty()
-  workflowInstanceId: string;
+  workflowId: string;
 
   @IsNotEmpty()
-  workstepInstanceId: string;
+  workstepId: string;
 
   @IsNotEmpty()
   fromSubjectAccountId: string;

--- a/examples/bri-3/src/bri/transactions/api/dtos/response/transaction.dto.ts
+++ b/examples/bri-3/src/bri/transactions/api/dtos/response/transaction.dto.ts
@@ -9,7 +9,13 @@ export class TransactionDto {
   nonce: number;
 
   @AutoMap()
+  workflowId: string;
+
+  @AutoMap()
   workflowInstanceId: string;
+
+  @AutoMap()
+  workstepId: string;
 
   @AutoMap()
   workstepInstanceId: string;

--- a/examples/bri-3/src/bri/transactions/api/transactions.controller.spec.ts
+++ b/examples/bri-3/src/bri/transactions/api/transactions.controller.spec.ts
@@ -210,8 +210,8 @@ describe('TransactionController', () => {
       const requestDto = {
         id: uuid(),
         nonce: 1,
-        workflowInstanceId: '42',
-        workstepInstanceId: '24',
+        workflowId: '42',
+        workstepId: '24',
         fromSubjectAccountId: fromBpiSubjectAccount.id,
         toSubjectAccountId: toBpiSubjectAccount.id,
         payload: 'payload1',
@@ -221,8 +221,8 @@ describe('TransactionController', () => {
       const expectedTransaction = new Transaction(
         requestDto.id,
         requestDto.nonce,
-        requestDto.workflowInstanceId,
-        requestDto.workstepInstanceId,
+        requestDto.workflowId,
+        requestDto.workstepId,
         fromBpiSubjectAccount,
         toBpiSubjectAccount,
         requestDto.payload,

--- a/examples/bri-3/src/bri/transactions/api/transactions.controller.ts
+++ b/examples/bri-3/src/bri/transactions/api/transactions.controller.ts
@@ -39,8 +39,8 @@ export class TransactionController {
       new CreateTransactionCommand(
         requestDto.id,
         requestDto.nonce,
-        requestDto.workflowInstanceId,
-        requestDto.workstepInstanceId,
+        requestDto.workflowId,
+        requestDto.workstepId,
         requestDto.fromSubjectAccountId,
         requestDto.toSubjectAccountId,
         requestDto.payload,

--- a/examples/bri-3/src/bri/transactions/capabilities/createTransaction/createTransaction.command.ts
+++ b/examples/bri-3/src/bri/transactions/capabilities/createTransaction/createTransaction.command.ts
@@ -2,8 +2,8 @@ export class CreateTransactionCommand {
   constructor(
     public readonly id: string,
     public readonly nonce: number,
-    public readonly workflowInstanceId: string,
-    public readonly workstepInstanceId: string,
+    public readonly workflowId: string,
+    public readonly workstepId: string,
     public readonly fromSubjectAccountId: string,
     public readonly toSubjectAccountId: string,
     public readonly payload: string,

--- a/examples/bri-3/src/bri/transactions/capabilities/createTransaction/createTransactionCommand.handler.ts
+++ b/examples/bri-3/src/bri/transactions/capabilities/createTransaction/createTransactionCommand.handler.ts
@@ -28,8 +28,8 @@ export class CreateTransactionCommandHandler
     const newTransactionCandidate = this.agent.createNewTransaction(
       command.id,
       command.nonce,
-      command.workflowInstanceId,
-      command.workstepInstanceId,
+      command.workflowId,
+      command.workstepId,
       subjectAccounts[0],
       subjectAccounts[1],
       command.payload,

--- a/examples/bri-3/src/bri/transactions/models/transaction.ts
+++ b/examples/bri-3/src/bri/transactions/models/transaction.ts
@@ -14,7 +14,13 @@ export class Transaction {
   workflowInstanceId: string;
 
   @AutoMap()
+  workflowId: string;
+
+  @AutoMap()
   workstepInstanceId: string;
+
+  @AutoMap()
+  workstepId: string;
 
   @AutoMap()
   fromBpiSubjectAccountId: string;
@@ -41,7 +47,9 @@ export class Transaction {
     id: string,
     nonce: number,
     workflowInstanceId: string,
+    workflowId: string,
     workstepInstanceId: string,
+    workstepId: string,
     fromBpiSubjectAccount: BpiSubjectAccount,
     toBpiSubjectAccount: BpiSubjectAccount,
     payload: string,
@@ -51,7 +59,9 @@ export class Transaction {
     this.id = id;
     this.nonce = nonce;
     this.workflowInstanceId = workflowInstanceId;
+    this.workflowId = workflowId;
     this.workstepInstanceId = workstepInstanceId;
+    this.workstepId = workstepId;
     this.fromBpiSubjectAccount = fromBpiSubjectAccount;
     this.fromBpiSubjectAccountId = fromBpiSubjectAccount?.id;
     this.toBpiSubjectAccount = toBpiSubjectAccount;

--- a/examples/bri-3/src/bri/transactions/models/transaction.ts
+++ b/examples/bri-3/src/bri/transactions/models/transaction.ts
@@ -46,9 +46,7 @@ export class Transaction {
   constructor(
     id: string,
     nonce: number,
-    workflowInstanceId: string,
     workflowId: string,
-    workstepInstanceId: string,
     workstepId: string,
     fromBpiSubjectAccount: BpiSubjectAccount,
     toBpiSubjectAccount: BpiSubjectAccount,
@@ -58,9 +56,7 @@ export class Transaction {
   ) {
     this.id = id;
     this.nonce = nonce;
-    this.workflowInstanceId = workflowInstanceId;
     this.workflowId = workflowId;
-    this.workstepInstanceId = workstepInstanceId;
     this.workstepId = workstepId;
     this.fromBpiSubjectAccount = fromBpiSubjectAccount;
     this.fromBpiSubjectAccountId = fromBpiSubjectAccount?.id;
@@ -71,6 +67,13 @@ export class Transaction {
     this.status = status;
   }
 
+  public updateWorkflowInstanceId(workflowInstanceId: string): void {
+    this.workflowInstanceId = workflowInstanceId;
+  }
+
+  public updateWorkstepInstanceId(workstepInstanceId: string): void {
+    this.workstepInstanceId = workstepInstanceId;
+  }
   public updatePayload(payload: string, signature: string): void {
     // TODO: Verify signature
     this.payload = payload;

--- a/examples/bri-3/src/bri/vsm/capabilites/executeVsmCycle/executeVsmCycleCommand.handler.ts
+++ b/examples/bri-3/src/bri/vsm/capabilites/executeVsmCycle/executeVsmCycleCommand.handler.ts
@@ -45,11 +45,11 @@ export class ExecuteVsmCycleCommandHandler
       }
 
       const workstep = await this.workstepStorageAgent.getWorkstepById(
-        tx.workstepInstanceId,
+        tx.workstepId,
       );
 
       const workflow = await this.workflowStorageAgent.getWorkflowById(
-        tx.workflowInstanceId,
+        tx.workflowId,
       );
 
       try {

--- a/examples/bri-3/test/sriUseCase.e2e-spec.ts
+++ b/examples/bri-3/test/sriUseCase.e2e-spec.ts
@@ -561,8 +561,8 @@ async function createWorkflowAndReturnId(
 async function createTransactionAndReturnId(
   id: string,
   nonce: number,
-  workflowInstanceId: string,
-  workstepInstanceId: string,
+  workflowId: string,
+  workstepId: string,
   fromSubjectAccountId: string,
   fromPrivatekey: string,
   toSubjectAccountId: string,
@@ -577,8 +577,8 @@ async function createTransactionAndReturnId(
     .send({
       id: id,
       nonce: nonce,
-      workflowInstanceId: workflowInstanceId,
-      workstepInstanceId: workstepInstanceId,
+      workflowId: workflowId,
+      workstepId: workstepId,
       fromSubjectAccountId: fromSubjectAccountId,
       toSubjectAccountId: toSubjectAccountId,
       payload: payload,


### PR DESCRIPTION
# Description

This PR adds workflowId and workstepId to transaction.
This values are generated once a transaction execution is started.

## Related Issue

#811 

## Motivation and Context

Previously, the values being stored was the workflowId and workstepId in the workflowInstanceId and workstepInstanceId

## How Has This Been Tested

All previous tests are running.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Request to be added as a Code Owner/Maintainer

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I commit to abide by the Responsibilities of Code Owners/Maintainers.
